### PR TITLE
20151108 Fix JSCS Errors

### DIFF
--- a/app/components/resource-block.js
+++ b/app/components/resource-block.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
   panel: 'info', // "info" or "counter"
 
   didInsertElement() {
-    let [swipeNode] = this.$();
+    let swipeNode = this.$().get(0);
     let hammertime = new Hammer(swipeNode);
 
     hammertime.on('panend panleft panright', (e) => {
@@ -31,7 +31,7 @@ export default Ember.Component.extend({
           return;
         }
 
-        percent = (100/roomWidth) * dx;
+        percent = (100 / roomWidth) * dx;
         this.translateNode(swipeNode, percent);
         break;
       case 'panright':
@@ -39,11 +39,11 @@ export default Ember.Component.extend({
           return;
         }
 
-        percent = (-50 + ((100/roomWidth) * dx));
+        percent = (-50 + ((100 / roomWidth) * dx));
         this.translateNode(swipeNode, percent);
         break;
       default: // on 'panend'
-        percent = (100/roomWidth) * dx;
+        percent = (100 / roomWidth) * dx;
 
         // if swiped more than halfway in either direction
         if (Math.abs(dx) > (roomWidth / 4)) {


### PR DESCRIPTION
Array destructuring was not working on the `$.this()` selection because jQuery objects are (apparently?) non-iterable inside whatever babel compiles into. The ember suave preset throws an error if `$.this()[0]` is used instead, so to get around it I'm just using `$.this().get(0)` so I don't have to disable any jscs rules for this line.
